### PR TITLE
Fix star rating when product has 0 reviews

### DIFF
--- a/client/src/components/shared/calcAvgTotalReviews.js
+++ b/client/src/components/shared/calcAvgTotalReviews.js
@@ -8,7 +8,7 @@ const calcAvgTotalReviews = (reviewsMetaData) => {
   }
 
   return {
-    avgStars: (stars/reviews).toFixed(1),
+    avgStars: reviews ? (stars/reviews).toFixed(1) : 0,
     reviews: reviews
   }
 }

--- a/client/src/components/shared/calcPctRecommend.js
+++ b/client/src/components/shared/calcPctRecommend.js
@@ -1,6 +1,8 @@
 const calcPctRecommend = (reviewMetaData) => {
+  let pct = 0;
   let totalReviews = parseInt(reviewMetaData.recommended.true) + parseInt(reviewMetaData.recommended.false);
-  return Math.round((reviewMetaData.recommended.true / totalReviews) * 100);
+  if (totalReviews > 0) { pct = Math.round((reviewMetaData.recommended.true / totalReviews) * 100); }
+  return pct;
 }
 
 export default calcPctRecommend;

--- a/client/src/components/shared/calcStarImg.jsx
+++ b/client/src/components/shared/calcStarImg.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const calcStarImg = (numStars) => {
+const calcStarImg = (numStars = 0) => {
   let starImg = [];
   let wholeStars = Math.floor(numStars);
   let fractionStar = numStars - Math.floor(numStars);


### PR DESCRIPTION
We found a bug where products with zero reviews would show:
- No star image
- NaN average rating
- NaN% recommended

This PR fixes the shared functions so that all modules will instead show:
- 5 empty stars
- 0 average rating
- 0% recommended

![image](https://user-images.githubusercontent.com/32132177/147993442-bf05d0c4-18c7-4159-8adf-2c5eb5ae0208.png)